### PR TITLE
Change ladder URL to coh2stats.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "en": "./data/coh2/RelicCoH2.English.ucs",
       "fr": "./data/coh2/RelicCoH2.French.ucs"
     },
-    "leaderboardUrl": "http://www.companyofheroes.com/leaderboards#profile/steam/{steamId}/standings",
+    "leaderboardUrl": "https://www.coh2.org/ladders/playercard/steamid/{steamId}",
     "expandChatPreview": {
       "reaction": "💬",
       "timeoutSeconds": 30

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "en": "./data/coh2/RelicCoH2.English.ucs",
       "fr": "./data/coh2/RelicCoH2.French.ucs"
     },
-    "leaderboardUrl": "https://www.coh2.org/ladders/playercard/steamid/{steamId}",
+    "leaderboardUrl": "https://coh2stats.com/players/{steamId}",
     "expandChatPreview": {
       "reaction": "💬",
       "timeoutSeconds": 30

--- a/src/commands/parse-replay/embed.ts
+++ b/src/commands/parse-replay/embed.ts
@@ -275,7 +275,7 @@ export abstract class ReplayBaseEmbed extends Discord.MessageEmbed {
         if (player.steam_id_str && player.steam_id_str != '0') {
             const url = (
                 this.config.leaderboardUrl ?? 
-                `http://www.companyofheroes.com/leaderboards#profile/steam/{steamId}/standings`
+                `https://www.coh2.org/ladders/playercard/steamid/{steamId}`
             )
                 .replace(/\{steamId\}/g, player.steam_id_str)
             ;

--- a/src/commands/parse-replay/embed.ts
+++ b/src/commands/parse-replay/embed.ts
@@ -275,7 +275,7 @@ export abstract class ReplayBaseEmbed extends Discord.MessageEmbed {
         if (player.steam_id_str && player.steam_id_str != '0') {
             const url = (
                 this.config.leaderboardUrl ?? 
-                `https://www.coh2.org/ladders/playercard/steamid/{steamId}`
+                `https://coh2stats.com/players/{steamId}`
             )
                 .replace(/\{steamId\}/g, player.steam_id_str)
             ;


### PR DESCRIPTION
The companyofheroes.com ladders were taken down, so the bot's ladder links lead to a 404 page. coh2.org is probably the best alternative.

Eg:

This link is broken
https://www.companyofheroes.com/leaderboards#profile/steam/76561198404414770/standings

This works
https://www.coh2.org/ladders/playercard/steamid/76561198404414770